### PR TITLE
Fix panic when pulling runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 .DS_Store
+.vscode
 Cargo.lock
 .env
 neo4j_volumes

--- a/src/agents/gitlab/consume/src/groups_consumer.rs
+++ b/src/agents/gitlab/consume/src/groups_consumer.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
                 println!("[**]GITLAB GROUP RUNNERS RECEIVED[**]");
                 for runner in link.resource_vec as Vec<Runner> {
                     let q = format!("OPTIONAL MATCH (n:GitlabRunner {{runner_id: \"{}\"}}) WITH n WHERE n IS NULL CREATE (r:GitlabRunner {{runner_id: \"{}\", runner_type: '{}', ip_address: '{}'}} )",
-                     runner.id, runner.id, runner.runner_type, runner.ip_address);
+                     runner.id, runner.id, runner.runner_type, runner.ip_address.unwrap_or_default());
                     transaction.run(Query::new(q)).await.expect("could not execute query");
                     let query = format!("MATCH (n:GitlabUserGroup) WHERE n.group_id = '{}' with n MATCH (r:GitlabRunner) WHERE r.runner_id = '{}' with n, r MERGE (r)-[:inGroup]->(n)", link.resource_id, runner.id);
                     println!("{}", query);

--- a/src/agents/gitlab/consume/src/main.rs
+++ b/src/agents/gitlab/consume/src/main.rs
@@ -135,7 +135,7 @@ async fn update_graph(message: MessageType, graph_conn: &Graph) -> Result<()> {
         },
         MessageType::Runners(vec) => {
             for runner in vec{
-                let query = format!("MERGE (n:GitlabRunner {{runner_id: '{}', ip_address: '{}', name: '{}' , runner_type: '{}', status: '{}', is_shared: '{}'}}) return n", runner.id, runner.ip_address, runner.name.unwrap_or_default(), runner.runner_type, runner.status, runner.is_shared.unwrap_or(false));
+                let query = format!("MERGE (n:GitlabRunner {{runner_id: '{}', ip_address: '{}', name: '{}' , runner_type: '{}', status: '{}', is_shared: '{}'}}) return n", runner.id, runner.ip_address.unwrap_or_default(), runner.name.unwrap_or_default(), runner.runner_type, runner.status, runner.is_shared.unwrap_or(false));
                 transaction.run(Query::new(query)).await.expect("could not execute query");
             }
         },

--- a/src/agents/gitlab/consume/src/runners_consumer.rs
+++ b/src/agents/gitlab/consume/src/runners_consumer.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
             MessageType::Runners(vec) => {
                 for runner in vec{
                     let query = format!("MERGE (n:GitlabRunner {{runner_id: '{}', ip_address: '{}', name: '{}' , runner_type: '{}', status: '{}', is_shared: '{}'}}) return n",
-                     runner.id, runner.ip_address, runner.name.unwrap_or_default(), 
+                     runner.id, runner.ip_address.unwrap_or_default(), runner.name.unwrap_or_default(), 
                      runner.runner_type, runner.status, runner.is_shared.unwrap_or(false));
 
                     transaction.run(Query::new(query)).await.expect("could not execute query");

--- a/src/agents/gitlab/observe/src/gitlab_projects.rs
+++ b/src/agents/gitlab/observe/src/gitlab_projects.rs
@@ -62,9 +62,8 @@ async fn main() -> Result<(), Box<dyn Error> > {
             publish_message(to_string(&MessageType::Projects(projects.clone())).unwrap().as_bytes(), &mq_publish_channel, GITLAB_EXCHANGE_STR, PROJECTS_ROUTING_KEY).await;
             
             for project in projects {
-                //get users of each project
+                // get users of each project
                 let users: Vec<User> = get_all_elements(&web_client, gitlab_token.clone(), format!("{}{}{}{}", service_endpoint, "/projects/" , project.id, "/users")).await.unwrap();
-
                 publish_message(to_string(&MessageType::ProjectUsers(ResourceLink {
                     resource_id: project.id,
                     resource_vec: users.clone()
@@ -76,19 +75,15 @@ async fn main() -> Result<(), Box<dyn Error> > {
                     resource_id: project.id, 
                     resource_vec: runners.clone() }))
                     .unwrap().as_bytes(), &mq_publish_channel, GITLAB_EXCHANGE_STR, PROJECTS_ROUTING_KEY).await;
-                //get 20 projects pipelines
                 
+                // get 20 projects pipelines
                 let pipelines: Vec<Pipeline> = get_project_pipelines(&web_client, project.id, gitlab_token.clone(), service_endpoint.clone()).await.unwrap();
-
                 publish_message(to_string(&MessageType::Pipelines(pipelines.clone())).unwrap().as_bytes(), &mq_publish_channel, GITLAB_EXCHANGE_STR, PROJECTS_ROUTING_KEY).await;
-
             }
             let _ = mq_conn.close(0, "closed").await?;
 
             //delete lock file
             remove_file(LOCK_FILE_PATH).expect("Error deleting lock file.");
-
-
             Ok(())
         }
     }

--- a/src/agents/gitlab/types/src/types.rs
+++ b/src/agents/gitlab/types/src/types.rs
@@ -145,7 +145,7 @@ pub struct Runner {
     pub is_shared: Option<bool>,
 
     pub description: Option<String>,
-    pub ip_address: String,
+    pub ip_address: Option<String>,
     pub runner_type: String,
 
     pub name: Option<String>,


### PR DESCRIPTION
The previous logic in gitlab web service did not account for the `ip_address` field of runners that never contacted the gitlab instance being null. New match case accounts for this to avoid a panic, and the field for ip_address is now optional, supporting serialization of null values.